### PR TITLE
mount /api volume from api instead of .

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ api:
   build: ./api
   command: bundle exec rackup -p 4567 -o 0.0.0.0
   volumes:
-    - .:/api
+    - api:/api
   ports:
     - "4567:4567"
   links:


### PR DESCRIPTION
This fixed it for me. Did you try this combo?
