### PR TITLE
Update elasticsearch image and volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 elastic:
-  image: dockerfile/elasticsearch
+  image: elasticsearch
   ports:
     - "9200:9200"
     - "9300:9300"
   volumes:
-    - docker_volumes/elasticsearch_data:/usr/local/elasticsearch/data
+    - elasticsearch_data:/usr/share/elasticsearch/data
 api:
   build: ./api
   command: bash ./deploy/start.sh


### PR DESCRIPTION
# Problem

Encountered an elasticsearch image error trying to run API-in-a-box:

```
Pulling elastic (dockerfile/elasticsearch:latest)...
Pulling repository docker.io/dockerfile/elasticsearch
ERROR: Error: image dockerfile/elasticsearch not found
```
# Solution

Update the Dockerfile to pull the official docker elasticsearch image and change the volume accordingly. 
